### PR TITLE
Update chrony.conf.j2

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -25,7 +25,7 @@ rtcsync
 #minsources 2
 
 # Allow NTP client access from local network.
-#allow 192.168.44.0/24	
+allow 192.168.44.0/24
 
 # Serve time even if not synchronized to a time source.
 #local stratum 10


### PR DESCRIPTION
added a new host inventory group with all servers but timeservers. when i ran the playbook with all servers, it overwrite the timeservers conf files and configured  them as client servers.